### PR TITLE
Fix "[Object object]" in admin/configuration

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.component.html
@@ -17,7 +17,7 @@
                 <div class="row" *ngFor="let key of keys(entry.properties)">
                     <div class="col-md-4">{{key}}</div>
                     <div class="col-md-8">
-                        <span class="float-right badge badge-default break">{{entry.properties[key]}}</span>
+                        <span class="float-right badge badge-default break">{{entry.properties[key] | json}}</span>
                     </div>
                 </div>
             </td>


### PR DESCRIPTION
Some objects are not clearly legible in the HTML.
(was OK in AngularJS)

![capture d ecran de 2017-04-10 15-05-15](https://cloud.githubusercontent.com/assets/11616517/24862999/66847af8-1dff-11e7-86f8-1804dae9061a.png)

Only have to add a JSON pipe.